### PR TITLE
chore: Remove has_rdoc= for Ruby 4.0 compatibility

### DIFF
--- a/data_uri.gemspec
+++ b/data_uri.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |s|
   s.summary     = "A URI class for parsing data URIs as per RFC2397"
 
   s.platform = Gem::Platform::RUBY
-  s.has_rdoc = true
   s.extra_rdoc_files = ["README.rdoc"]
 
   s.require_path = 'lib'


### PR DESCRIPTION
`Gem::Specification#has_rdoc=` was removed in Ruby 4.0. This line causes a hard `undefined method 'has_rdoc='` error when Bundler loads the gemspec under Ruby 4.0+.

`has_rdoc=` has been a no-op since RubyGems 1.9 (circa 2011). It was silently ignored for over a decade before being fully removed in Ruby 4.0.

Changes:
- data_uri.gemspec: Remove `s.has_rdoc = true`